### PR TITLE
Add a workflow to attach label based on PR branchname directly to `develop`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - "changelog: none"
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Fixed 🛠
+      labels:
+        - "changelog: fix"
+        - "type: bug"
+    - title: New Features 🎉
+      labels:
+        - "changelog: add"
+        - "type: enhancement"
+    - title: Updated
+      labels:
+        - "changelog: update"
+    - title: Tweaked
+      labels:
+        - "changelog: tweak"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -1,0 +1,12 @@
+name: Add Branch Type Label
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  SetLabels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set labels
+        uses: woocommerce/grow/packages/js/github-actions/actions/branch-label@add/label-action


### PR DESCRIPTION
Use Branch Type Label GHA from `/grow` repo

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - a workflow to attach label based on PR branchname directly to `develop`
